### PR TITLE
Add FileNotFoundException as cause for RuntimeException instead of suppressing it

### DIFF
--- a/Vanilla Injection/src/com/energyxxer/inject/InjectionMaster.java
+++ b/Vanilla Injection/src/com/energyxxer/inject/InjectionMaster.java
@@ -342,7 +342,7 @@ public class InjectionMaster {
             lastLine = linesScanned + 1;
         } catch(FileNotFoundException x) {
             stop();
-            throw new RuntimeException("Log file not found. Stopping injection.");
+            throw new RuntimeException("Log file not found. Stopping injection.", x);
         } finally {
             if(mute) mute = false;
             if (inputStream != null) {


### PR DESCRIPTION
Please never suppress the cause of an exception like this, it just makes it more difficult to find the error, for instance in this case you suppress the name of the file that is missing.